### PR TITLE
Fixed inappropriate attribute of aci_subnet

### DIFF
--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -27,7 +27,7 @@ resource "aci_bridge_domain" "bd_for_subnet" {
 resource "aci_subnet" "demosubnet" {
   parent_dn                    = "${aci_bridge_domain.bd_for_subnet.id}"
   ip                                  = "172.16.1.1/24"
-  scope                               = "private"
+  scope                               = ["private"]
   description                         = "This subject is created by Terraform v3"
 }
 


### PR DESCRIPTION
The attribute "scope" of resource "ac_subnet" should be list of string.